### PR TITLE
v2.2.0 - Added validation checker to prevent repeated keys among monitor maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Terraform module to create communication between NewRelic and PagerDuty
 | Name | Version |
 |------|---------|
 | <a name="provider_newrelic"></a> [newrelic](#provider\_newrelic) | 3.52.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 | <a name="provider_pagerduty"></a> [pagerduty](#provider\_pagerduty) | 3.4.0 |
 
 ## Modules
@@ -67,6 +68,7 @@ No modules.
 | [newrelic_workflow.non_critical_apm_response_time](https://registry.terraform.io/providers/newrelic/newrelic/3.52.0/docs/resources/workflow) | resource |
 | [newrelic_workflow.non_critical_browser_pageload](https://registry.terraform.io/providers/newrelic/newrelic/3.52.0/docs/resources/workflow) | resource |
 | [newrelic_workflow.this](https://registry.terraform.io/providers/newrelic/newrelic/3.52.0/docs/resources/workflow) | resource |
+| [null_resource.check_unique_monitor_keys](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [pagerduty_service.critical](https://registry.terraform.io/providers/PagerDuty/pagerduty/3.4.0/docs/resources/service) | resource |
 | [pagerduty_service.non_critical](https://registry.terraform.io/providers/PagerDuty/pagerduty/3.4.0/docs/resources/service) | resource |
 | [pagerduty_service.synthetics_newrelic](https://registry.terraform.io/providers/PagerDuty/pagerduty/3.4.0/docs/resources/service) | resource |

--- a/validations.tf
+++ b/validations.tf
@@ -1,0 +1,23 @@
+locals {
+  all_monitors_list = [
+    var.simple_monitors, var.browser_monitors,
+    var.script_monitors, var.step_monitors,
+    var.broken_links_monitors, var.cert_check_monitors
+  ]
+
+  all_monitor_keys = flatten([for i in local.all_monitors_list : keys(i)])
+
+  # checks for all distinct keys only
+  all_distinct_monitor_keys = distinct(local.all_monitor_keys)
+}
+
+# Since all monitor maps are merged, all keys between different types of monitors need to be unique to avoid 
+# overwriting values.
+resource "null_resource" "check_unique_monitor_keys" {
+  lifecycle {
+    precondition {
+      condition     = length(local.all_monitor_keys) == length(local.all_distinct_monitor_keys)
+      error_message = "Monitor keys need to be unique among all monitor objects."
+    }
+  }
+}


### PR DESCRIPTION
Dummy test:

```
│ Error: Resource precondition failed
│ 
│   on .terraform/modules/nr_pd/validations.tf line 17, in resource "null_resource" "check_unique_monitor_keys":
│   17:       condition     = length(local.all_monitor_keys)==0 #length(local.all_monitor_keys) == length(local.all_distinct_monitor_keys)
│     ├────────────────
│     │ local.all_monitor_keys is tuple with 5 elements
│ 
│ Monitor keys need to be unique among all monitor objects.
```